### PR TITLE
Support a custom location for project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *.gz
 
 /backups
+/compiled
 /shared-config/nginx/conf.d/*.conf
 /shared-config/apache/sites-enabled/*

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Elasticsearch
 This Docker config setup makes some assumptions about your local environment.
 
 * You'll need to clone this repository (or symlink it) to a path in your home directory (e.g., `~/system/`).
-* Your projects (WordPress sites, projects, etc) will need to be in `~/projects/`
+* Your projects (WordPress sites, projects, etc) will need to be in `~/projects/`. Note: You can change this default by declaring `$DOCKER_PROJECT_DIR` in your `.bashrc`/`.zshrc`
 
 #### brew
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source ./setup-dirs.sh
+
 # install docker
 echo 'Installing docker via brew'
 brew install docker

--- a/setup-dirs.sh
+++ b/setup-dirs.sh
@@ -6,7 +6,6 @@ rm -rf compiled/*
 cp -r launch compiled/launch
 cp -r shared-config compiled/shared-config
 
-
 if [ -z "${DOCKER_PROJECT_DIR}" ]; then
 	echo
 	echo "DOCKER_PROJECT_DIR is not set. Defaulting to ~/projects/ for your source code"

--- a/setup-dirs.sh
+++ b/setup-dirs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# setup compiled dir
+mkdir -p compiled
+rm -rf compiled/*
+cp -r launch compiled/launch
+cp -r shared-config compiled/shared-config
+
+
+if [ -z "${DOCKER_PROJECT_DIR}" ]; then
+	echo
+	echo "DOCKER_PROJECT_DIR is not set. Defaulting to ~/projects/ for your source code"
+	echo "If you wish to change the location of your project source code, please specify"
+	echo "DOCKER_PROJECT_DIR in your bashrc or zshrc and re-run ./setup-dirs.sh"
+	echo
+else
+	DOCKER_PROJECT_DIR_REGEX=$(echo $DOCKER_PROJECT_DIR | sed 's/\//\\\//g')
+
+	# replace references to ~/projects with the dir the user has set up
+	find compiled/ -type f -exec sed -i '' -e "s/~\/projects/${DOCKER_PROJECT_DIR_REGEX}/g" {} +
+fi

--- a/start.sh
+++ b/start.sh
@@ -4,7 +4,7 @@ REPODIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 if [[ $1 ]]
 then
-	/bin/bash "$REPODIR/launch/$1.sh"
+	/bin/bash "$REPODIR/compiled/launch/$1.sh"
 else
-	/bin/bash "$REPODIR/launch/lnmp.sh"
+	/bin/bash "$REPODIR/compiled/launch/lnmp.sh"
 fi


### PR DESCRIPTION
Default to `~/projects` but allow that setting to be overridden with an environment variable: `$DOCKER_PROJECT_DIR`.  Changing that value will require a re-setting-up of the scripts via `setup-dirs.sh`.

This _does_ add a "compiled" directory where scripts have a recursive `sed` command executed on them. I'm not sure how well that'll play as folks add custom nginx/apache config files.
